### PR TITLE
Fix: data bytes of opCodeExpireTime

### DIFF
--- a/core/decoder.go
+++ b/core/decoder.go
@@ -220,11 +220,11 @@ func (dec *Decoder) parse(cb func(object model.RedisObject) bool) error {
 			dbIndex = int(dbIndex64)
 			continue
 		} else if b == opCodeExpireTime {
-			err = dec.readFull(dec.buffer)
+			err = dec.readFull(dec.buffer[:4])
 			if err != nil {
 				return err
 			}
-			expireMs = int64(binary.LittleEndian.Uint64(dec.buffer)) * 1000
+			expireMs = int64(binary.LittleEndian.Uint32(dec.buffer)) * 1000
 			continue
 		} else if b == opCodeExpireTimeMs {
 			err = dec.readFull(dec.buffer)


### PR DESCRIPTION
Hi, data bytes for opCodeExpireTime parts should be 4, as shown in [decoder of rdbFlagExpiry](https://github.com/tent/rdb/blob/43ba34106c765f2111c0dc7b74cdf8ee437411e0/decoder.go#L191) and [redis RDB rdbLoadTime](https://github.com/redis/redis/blob/e2fa6aa1589ef88322d16872bd6a94cdd21f353f/src/rdb.c#L128)