### PR TITLE
Fix: decoder parse panic recover

### DIFF
--- a/core/decoder.go
+++ b/core/decoder.go
@@ -299,8 +299,7 @@ func (dec *Decoder) parse(cb func(object model.RedisObject) bool) error {
 
 // Parse parses rdb and callback
 // cb returns true to continue, returns false to stop the iteration
-func (dec *Decoder) Parse(cb func(object model.RedisObject) bool) error {
-	var err error
+func (dec *Decoder) Parse(cb func(object model.RedisObject) bool) (err error) {
 	defer func() {
 		if err2 := recover(); err2 != nil {
 			err = fmt.Errorf("panic: %v", err2)


### PR DESCRIPTION
Hi, I found there is a mistake of Decoder panic recover.

## How To Reproduction

You panic in Decoder Parser, where `panic("just test panic")` is added for test on purpose.

```golang
func (dec *Decoder) Parse(cb func(object model.RedisObject) bool) (err error) {
	defer func() {
		if err2 := recover(); err2 != nil {
			err = fmt.Errorf("panic: %v", err2)
		}
	}()
	panic("just test panic")
	err = dec.checkHeader()
	if err != nil {
		return err
	}
	return dec.parse(cb)
}
```

and run cmd `go test parser_test.go`, there will show you info:

```plain
--- FAIL: TestToJson (0.01s)
    parser_test.go:103: error occurs during parse memory, err: panic: just test panic
    parser_test.go:103: error occurs during parse quicklist, err: panic: just test panic
    parser_test.go:103: error occurs during parse easily_compressible_string_key, err: panic: just test panic
    parser_test.go:103: error occurs during parse empty_database, err: panic: just test panic
    parser_test.go:103: error occurs during parse hash, err: panic: just test panic
    parser_test.go:103: error occurs during parse hash_as_ziplist, err: panic: just test panic
    parser_test.go:103: error occurs during parse integer_keys, err: panic: just test panic
    parser_test.go:103: error occurs during parse intset_16, err: panic: just test panic
    parser_test.go:103: error occurs during parse intset_32, err: panic: just test panic
    parser_test.go:103: error occurs during parse intset_64, err: panic: just test panic
    parser_test.go:103: error occurs during parse keys_with_expiry, err: panic: just test panic
    parser_test.go:103: error occurs during parse linkedlist, err: panic: just test panic
    parser_test.go:103: error occurs during parse multiple_databases, err: panic: just test panic
    parser_test.go:103: error occurs during parse non_ascii_values, err: panic: just test panic
    parser_test.go:103: error occurs during parse parser_filters, err: panic: just test panic
    parser_test.go:103: error occurs during parse rdb_version_5_with_checksum, err: panic: just test panic
    parser_test.go:103: error occurs during parse rdb_version_8_with_64b_length_and_scores, err: panic: just test panic
    parser_test.go:103: error occurs during parse regular_set, err: panic: just test panic
    parser_test.go:103: error occurs during parse regular_sorted_set, err: panic: just test panic
    parser_test.go:103: error occurs during parse sorted_set_as_ziplist, err: panic: just test panic
    parser_test.go:103: error occurs during parse uncompressible_string_keys, err: panic: just test panic
    parser_test.go:103: error occurs during parse ziplist_that_compresses_easily, err: panic: just test panic
    parser_test.go:103: error occurs during parse ziplist_that_doesnt_compress, err: panic: just test panic
    parser_test.go:103: error occurs during parse ziplist_with_integers, err: panic: just test panic
    parser_test.go:103: error occurs during parse zipmap_that_compresses_easily, err: panic: just test panic
    parser_test.go:103: error occurs during parse zipmap_that_doesnt_compress, err: panic: just test panic
    parser_test.go:103: error occurs during parse zipmap_with_big_values, err: panic: just test panic
    parser_test.go:103: error occurs during parse zipmap_big_len, err: panic: just test panic
--- FAIL: TestMemoryProfile (0.00s)
    parser_test.go:142: error occurs during parse cases/memory.rdb, err: panic: just test panic
--- FAIL: TestToAof (0.00s)
    parser_test.go:180: error occurs during parse cases/memory.rdb, err: panic: just test panic
--- FAIL: TestFindLargestKeys (0.00s)
    parser_test.go:223: FindLargestKeys failed: panic: just test panic
    parser_test.go:39: line number is not equal
    parser_test.go:236: result is not equal of cases/memory.rdb
--- FAIL: TestFlameGraph (0.00s)
    parser_test.go:255: FindLargestKeys failed: panic: just test panic
    parser_test.go:259: Get "http://localhost:18888/flamegraph": dial tcp 127.0.0.1:18888: connect: connection refused
FAIL
FAIL    command-line-arguments  0.099s
FAIL
```


