### PR TITLE
upgrade to use go1.19 and add github action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: build
+
+on: push
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    - name: test
+      run: go test ./...
+    - name: build
+      run: go build -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: go
-
-go:
-  - 1.16.x
-before_install:
-  - go install github.com/mattn/goveralls@latest
-script:
-  - $GOPATH/bin/goveralls -service=travis-ci

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/hdt3213/rdb
 
-go 1.16
+go 1.19
 
 require github.com/emirpasic/gods v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
-github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
- remove travis and add github action workflow
- bump to use go1.19