### PR TITLE
fix: correctly parse listpack entry len for short string

### DIFF
--- a/core/listpack.go
+++ b/core/listpack.go
@@ -92,7 +92,7 @@ func (dec *Decoder) readListPackEntry(buf []byte, cursor *int) ([]byte, uint32, 
 	case 14: // 1110 xxxx -> str, type(len) == uint12
 		dec.buffer[0] = header & 0x0f
 		dec.buffer[1], err = readByte(buf, cursor)
-		strLen := binary.LittleEndian.Uint32(dec.buffer[:2])
+		strLen := binary.BigEndian.Uint16(dec.buffer[:2])
 		result, err := readBytes(buf, cursor, int(strLen))
 		if err != nil {
 			return nil, 0, err


### PR DESCRIPTION
I found an error during parsing listpack-encoded value.
Exact values for `dec.buffer[0]` and `dec.buffer[1]` were `1110 0000` and `1000 0000`. According to [listpack spec](https://gist.github.com/antirez/66ffab20190ece8a7485bd9accfbc175#multi-byte-encodings) the most significant bits are stored first.