### PR TITLE
feat: Add custom module type support

### DIFF
--- a/core/decoder.go
+++ b/core/decoder.go
@@ -70,7 +70,7 @@ const (
 	typeHash
 	typeZset2 /* ZSET version 2 with doubles stored in binary. */
 	typeModule
-	typeModule2 // Module should import module entity, not support at present.
+	typeModule2 // Module value parser should be registered with Decoder.WithSpecialType
 	_
 	typeHashZipMap
 	typeListZipList

--- a/core/module.go
+++ b/core/module.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 )
 
-type Opcode int
+type Opcode uint8
 
 const (
-	OpcodeEOF    Opcode = 0
-	OpcodeSInt          = 1
-	OpcodeUInt          = 2
-	OpcodeFloat         = 3
-	OpcodeDouble        = 4
-	OpcodeString        = 5
+	ModuleOpcodeEOF Opcode = iota
+	ModuleOpcodeSInt
+	ModuleOpcodeUInt
+	ModuleOpcodeFloat
+	ModuleOpcodeDouble
+	ModuleOpcodeString
 )
 
 type ModuleTypeHandler interface {
@@ -88,24 +88,24 @@ func (dec *Decoder) handleModuleType(moduleId uint64) (string, interface{}, erro
 	if !found {
 		return moduleType, nil, fmt.Errorf("unknown module type: %s", moduleType)
 	}
-	encVersion := moduleId & 1023
+	encVersion := moduleTypeEncVersionByID(moduleId)
 	val, err := handler(moduleTypeHandlerImpl{dec: dec}, int(encVersion))
 	return moduleType, val, err
 }
 
-func moduleTypeNameByID(moduleid uint64) string {
-
+func moduleTypeNameByID(moduleId uint64) string {
 	cset := ModuleTypeNameCharSet
-
 	name := make([]byte, 9)
-
-	moduleid >>= 10
+	moduleId >>= 10
 	for j := 0; j < 9; j++ {
-		name[8-j] = cset[moduleid&63]
-		moduleid >>= 6
+		name[8-j] = cset[moduleId&63]
+		moduleId >>= 6
 	}
-
 	return string(name)
+}
+
+func moduleTypeEncVersionByID(moduleId uint64) uint64 {
+	return moduleId & 1023
 }
 
 const ModuleTypeNameCharSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"

--- a/core/module.go
+++ b/core/module.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Opcode int
+
+const (
+	OpcodeEOF    Opcode = 0
+	OpcodeSInt          = 1
+	OpcodeUInt          = 2
+	OpcodeFloat         = 3
+	OpcodeDouble        = 4
+	OpcodeString        = 5
+)
+
+type ModuleTypeHandler interface {
+	ReadByte() (byte, error)
+	ReadFull(buf []byte) error
+	ReadOpcode() (Opcode, error)
+	ReadUInt() (uint64, error)
+	ReadSInt() (int64, error)
+	ReadDouble() (float64, error)
+	ReadString() ([]byte, error)
+	ReadLength() (uint64, bool, error)
+}
+
+type moduleTypeHandlerImpl struct {
+	dec *Decoder
+}
+
+func (m moduleTypeHandlerImpl) ReadByte() (byte, error) {
+	return m.dec.readByte()
+}
+
+func (m moduleTypeHandlerImpl) ReadFull(buf []byte) error {
+	return m.dec.readFull(buf)
+}
+
+func (m moduleTypeHandlerImpl) ReadOpcode() (Opcode, error) {
+	code, _, err := m.dec.readLength()
+	if err != nil {
+		return 0, err
+	}
+	if code > 5 {
+		return 0, errors.New("unknown opcode")
+	}
+	return Opcode(code), nil
+}
+
+func (m moduleTypeHandlerImpl) ReadUInt() (uint64, error) {
+	val, _, err := m.dec.readLength()
+	return val, err
+}
+
+func (m moduleTypeHandlerImpl) ReadSInt() (int64, error) {
+	val, _, err := m.dec.readLength()
+	return int64(val), err
+}
+
+func (m moduleTypeHandlerImpl) ReadDouble() (float64, error) {
+	return m.dec.readFloat()
+}
+
+func (m moduleTypeHandlerImpl) ReadString() ([]byte, error) {
+	return m.dec.readString()
+}
+
+func (m moduleTypeHandlerImpl) ReadLength() (uint64, bool, error) {
+	return m.dec.readLength()
+}
+
+type ModuleTypeHandleFunc func(handler ModuleTypeHandler, encVersion int) (interface{}, error)
+
+func (dec *Decoder) readModuleType() (string, interface{}, error) {
+	moduleId, _, err := dec.readLength()
+	if err != nil {
+		return "", nil, err
+	}
+	return dec.handleModuleType(moduleId)
+}
+
+func (dec *Decoder) handleModuleType(moduleId uint64) (string, interface{}, error) {
+	moduleType := moduleTypeNameByID(moduleId)
+	handler, found := dec.withSpecialTypes[moduleType]
+	if !found {
+		return moduleType, nil, fmt.Errorf("unknown module type: %s", moduleType)
+	}
+	encVersion := moduleId & 1023
+	val, err := handler(moduleTypeHandlerImpl{dec: dec}, int(encVersion))
+	return moduleType, val, err
+}
+
+func moduleTypeNameByID(moduleid uint64) string {
+
+	cset := ModuleTypeNameCharSet
+
+	name := make([]byte, 9)
+
+	moduleid >>= 10
+	for j := 0; j < 9; j++ {
+		name[8-j] = cset[moduleid&63]
+		moduleid >>= 6
+	}
+
+	return string(name)
+}
+
+const ModuleTypeNameCharSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"

--- a/core/module_test.go
+++ b/core/module_test.go
@@ -1,0 +1,200 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/hdt3213/rdb/model"
+	"testing"
+)
+
+const testModuleType = "test-type"
+
+func TestModuleType(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	enc := NewEncoder(buf)
+
+	key := "testkey"
+	expectedModuleEncVersion := uint64(42)
+	expectedStrData := "testdata123"
+	expectedUInt := uint64(123)
+
+	err := enc.WriteHeader()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = enc.WriteDBHeader(0, 1, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.beforeWriteObject()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.write([]byte{typeModule2})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.writeString(key)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	moduleId := createModuleId(testModuleType, expectedModuleEncVersion)
+	err = enc.writeLength(moduleId)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.writeLength(uint64(ModuleOpcodeString))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.writeString(expectedStrData)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.writeLength(uint64(ModuleOpcodeUInt))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = enc.writeLength(expectedUInt)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = enc.writeLength(uint64(ModuleOpcodeEOF))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	enc.state = writtenObjectState
+
+	err = enc.WriteEnd()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	expectedResult := "expected-result"
+
+	dec := NewDecoder(buf).WithSpecialType(testModuleType,
+		func(h ModuleTypeHandler, encVersion int) (interface{}, error) {
+			if encVersion != 42 {
+				t.Errorf("invalid encoding version, expected %d, actual %d",
+					expectedModuleEncVersion, encVersion)
+				return nil, fmt.Errorf("invalid encoding version, expected %d, actual %d",
+					expectedModuleEncVersion, encVersion)
+			}
+
+			opcode, err := h.ReadOpcode()
+			if err != nil {
+				return nil, err
+			}
+			if opcode != ModuleOpcodeString {
+				return nil, fmt.Errorf("invalid opcode read, expected %d (string), actual %d",
+					ModuleOpcodeString, opcode)
+			}
+			data, err := h.ReadString()
+			if err != nil {
+				return nil, err
+			}
+			if !bytes.Equal(data, []byte(expectedStrData)) {
+				return nil, fmt.Errorf("invalid string data read, expected %s, actual %s",
+					expectedStrData, string(data))
+			}
+
+			opcode, err = h.ReadOpcode()
+			if err != nil {
+				return nil, err
+			}
+			if opcode != ModuleOpcodeUInt {
+				return nil, fmt.Errorf("invalid opcode read, expected %d (uint), actual %d",
+					ModuleOpcodeUInt, opcode)
+			}
+			val, err := h.ReadUInt()
+			if err != nil {
+				return nil, err
+			}
+			if val != expectedUInt {
+				return nil, fmt.Errorf("invalid unsigned int read, expected %d, actual %d",
+					expectedUInt, val)
+			}
+			opcode, err = h.ReadOpcode()
+			if err != nil {
+				return nil, err
+			}
+			if opcode != ModuleOpcodeEOF {
+				return nil, fmt.Errorf("invalid opcode read, expected %d (EOF), actual %d",
+					ModuleOpcodeEOF, opcode)
+			}
+			return expectedResult, nil
+		})
+
+	err = dec.Parse(func(o model.RedisObject) bool {
+		if o.GetKey() != key {
+			t.Errorf("invalid object key, expected %s, actual %s", key, o.GetKey())
+			return false
+		}
+		if o.GetType() != testModuleType {
+			t.Errorf("invalid redis type, expected %s, actual %s", testModuleType, o.GetType())
+			return false
+		}
+		mtObj, ok := o.(*model.ModuleTypeObject)
+		if !ok {
+			t.Errorf("invalid object type, expected model.ModuleTypeObject")
+			return false
+		}
+
+		if mtObj.Value != expectedResult {
+			t.Errorf("invalid return value")
+			return false
+		}
+
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCorrectModuleTypeEncodeDecode(t *testing.T) {
+	moduleId := createModuleId(testModuleType, 42)
+	name := moduleTypeNameByID(moduleId)
+	encVersion := moduleTypeEncVersionByID(moduleId)
+	if name != testModuleType {
+		t.Errorf("invalid module type name, expected %s, actual %s", testModuleType, name)
+	}
+	if encVersion != 42 {
+		t.Errorf("invalid module encoding version, expected %d, actual %d", 42, encVersion)
+	}
+}
+
+func createModuleId(moduleType string, encVersion uint64) uint64 {
+	moduleId := uint64(0)
+	for i := 0; i < 9; i++ {
+		moduleId |= uint64(charCode(moduleType[i]))
+		moduleId <<= 6
+	}
+	moduleId <<= 4
+	moduleId |= encVersion
+	return moduleId
+}
+
+func charCode(c uint8) uint8 {
+	for i, csChar := range []byte(ModuleTypeNameCharSet) {
+		if c == csChar {
+			return uint8(i)
+		}
+	}
+	panic(fmt.Errorf("unsupported char %c", c))
+}

--- a/model/model.go
+++ b/model/model.go
@@ -288,3 +288,29 @@ type DBSizeObject struct {
 func (o *DBSizeObject) GetType() string {
 	return DBSizeType
 }
+
+// ModuleTypeObject stores a module type object parsed by custom handler
+type ModuleTypeObject struct {
+	*BaseObject
+	ModuleType string
+	Value      interface{}
+}
+
+// GetType returns module type name
+func (o *ModuleTypeObject) GetType() string {
+	return o.ModuleType
+}
+
+// MarshalJSON marshal []byte as string
+func (o *ModuleTypeObject) MarshalJSON() ([]byte, error) {
+	o2 := struct {
+		*BaseObject
+		ModuleType string      `json:"moduleType"`
+		Value      interface{} `json:"value"`
+	}{
+		BaseObject: o.BaseObject,
+		ModuleType: o.ModuleType,
+		Value:      o.Value,
+	}
+	return json.Marshal(o2)
+}


### PR DESCRIPTION
This is a suggestion to add support for custom module type parsing by allowing the user of a library to implement it.

Example usage:
```go
const myType = "mytypeid"

func parse() {
	decoder := core.NewDecoder(r).WithSpecialType(ftsIndexType, parseMyType)
}

func parseMyType(h core.ModuleTypeHandler, encVersion int) (interface{}, error) {
	opcode, err := h.ReadOpcode()
	if err != nil {
		return nil, err
	}
	if opcode != core.OpcodeString {
		return nil, errors.New("unsupported module type value code")
	}

	data, err := h.ReadString()
	if err != nil {
		return nil, err
	}

	val := model.MyModel{}
	err = json.Unmarshal(data, &val)
	if err != nil {
		return nil, err
	}

	opcode, err = h.ReadOpcode()
	if err != nil || opcode != core.OpcodeEOF {
		return nil, errors.New("expected module type value EOF")
	}

	return &val, nil
}
```

This implementation was used in my fork for my project, but it would be nice to have it supported in your library.

I'm open to any comments about the design of the solution and ready to update the PR in my free time if anything required.