### PR TITLE
fix encode string as integer

### DIFF
--- a/core/encoder_test.go
+++ b/core/encoder_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"github.com/hdt3213/rdb/model"
+	"math/rand"
 	"testing"
 	"time"
 )
@@ -18,11 +19,15 @@ func TestEncode(t *testing.T) {
 		TTL   uint64
 	}
 	strMap := map[string]*valTTLPair{
-		"a":            {Value: "a", TTL: uint64(time.Now().Add(time.Hour).Unix())},
-		"b":            {Value: "b", TTL: uint64(time.Now().Add(time.Minute).Unix())},
-		"c":            {Value: "c"},
-		"1":            {Value: "1"},
-		RandString(20): {Value: RandString(20)},
+		"a": {Value: "a", TTL: uint64(time.Now().Add(time.Hour).Unix())},
+		"b": {Value: "b", TTL: uint64(time.Now().Add(time.Minute).Unix())},
+		"c": {Value: "c"},
+		"1": {Value: "1"},
+	}
+	for i := 0; i < 1000; i++ {
+		strMap[RandString(rand.Intn(20))] = &valTTLPair{
+			Value: RandString(rand.Intn(50)),
+		}
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/core/hash.go
+++ b/core/hash.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/binary"
 	"errors"
-
 	"github.com/hdt3213/rdb/model"
 )
 

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -18,6 +18,12 @@ func TestHashEncoding(t *testing.T) {
 			"n": []byte(RandString(128)),
 			"o": []byte(RandString(128)),
 		},
+		"001": {
+			"007": []byte(RandString(128)),
+		},
+		"000": {
+			"0x11": []byte(RandString(128)),
+		},
 	}
 	m := make(map[string][]byte)
 	for i := 0; i < 1024; i++ {

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"github.com/hdt3213/rdb/model"
+	"math/rand"
 	"testing"
 )
 
@@ -27,7 +28,7 @@ func TestHashEncoding(t *testing.T) {
 	}
 	m := make(map[string][]byte)
 	for i := 0; i < 1024; i++ {
-		m[RandString(64)] = []byte(RandString(128))
+		m[RandString(rand.Intn(32))] = []byte(RandString(rand.Intn(128)))
 	}
 	mapMap["large"] = m
 	buf := bytes.NewBuffer(nil)

--- a/core/list_test.go
+++ b/core/list_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"bytes"
 	"github.com/hdt3213/rdb/model"
+	"math"
+	"strconv"
 	"testing"
 )
 
@@ -17,6 +19,12 @@ func TestListEncoding(t *testing.T) {
 		},
 		"1": {
 			[]byte("1"), []byte("2"), []byte("3"), []byte("4"),
+		},
+		"001": {
+			[]byte("001"), []byte("0x11"), []byte("000"), []byte("0"),
+		},
+		"0": {
+			[]byte("0x11"), []byte("001"), []byte("11111111"), []byte("1"),
 		},
 		"large": list,
 	}
@@ -72,19 +80,38 @@ func TestZipListEncoding(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	enc := NewEncoder(buf).SetListZipListOpt(64, 64)
 	list := []string{
+		"",
 		"0",
 		"1",
-		"12",
 		"13",
-		"-1",
 		"127",
+		"32766",
 		"8388607",
 		"16777216",
 		"2147483647",
 		"21474836471",
 		"a",
+		"abc",
+		"007",
+		"+0",
+		"-0",
+		"+1",
+		"-1",
+		"0x11",
+		"0o00",
+		strconv.Itoa(math.MaxInt8),
+		strconv.Itoa(math.MinInt8),
+		strconv.Itoa(math.MaxInt16),
+		strconv.Itoa(math.MinInt16),
+		strconv.Itoa(math.MaxInt32),
+		strconv.Itoa(math.MinInt32),
+		strconv.Itoa(math.MinInt32) + "1",
+		strconv.Itoa(math.MaxInt64),
+		strconv.Itoa(math.MinInt64),
+		strconv.Itoa(math.MinInt64) + "1",
 		RandString(60),
 		RandString(1638),
+		RandString(10000),
 	}
 	err := enc.writeZipList(list)
 	if err != nil {

--- a/core/list_test.go
+++ b/core/list_test.go
@@ -140,8 +140,6 @@ func TestZipListEncoding(t *testing.T) {
 }
 
 func TestRandomZipListEncoding(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
-	enc := NewEncoder(buf).SetListZipListOpt(64, 64)
 	size := 32
 	round := 10000
 	list := make([]string, size)
@@ -149,6 +147,8 @@ func TestRandomZipListEncoding(t *testing.T) {
 		for i := 0; i < size; i++ {
 			list[i] = RandString(rand.Intn(50))
 		}
+		buf := bytes.NewBuffer(nil)
+		enc := NewEncoder(buf).SetListZipListOpt(64, 64)
 		err := enc.writeZipList(list)
 		if err != nil {
 			t.Error(err)

--- a/core/set.go
+++ b/core/set.go
@@ -95,12 +95,11 @@ func (enc *Encoder) WriteSetObject(key string, values [][]byte, options ...inter
 	if err != nil {
 		return err
 	}
-	if ok {
-		return nil
-	}
-	err = enc.writeSetEncoding(key, values)
-	if err != nil {
-		return err
+	if !ok {
+		err = enc.writeSetEncoding(key, values)
+		if err != nil {
+			return err
+		}
 	}
 	enc.state = writtenObjectState
 	return nil

--- a/core/set.go
+++ b/core/set.go
@@ -134,8 +134,8 @@ func (enc *Encoder) tryWriteIntSetEncoding(key string, values [][]byte) (bool, e
 	intList := make([]int64, len(values))
 	for i, v := range values {
 		str := unsafeBytes2Str(v)
-		intV, err := strconv.ParseInt(str, 10, 64)
-		if err != nil {
+		intV, ok := isEncodableUint64(str)
+		if !ok {
 			return false, nil
 		}
 		if intV < min {

--- a/core/set_test.go
+++ b/core/set_test.go
@@ -23,6 +23,9 @@ func TestSetEncoding(t *testing.T) {
 		"8": {
 			[]byte("-9222147483647"), []byte("9222147483647"),
 		},
+		"007": {
+			[]byte("-1"), []byte("02"), []byte("0x3"), []byte("0o4"),
+		},
 	}
 	buf := bytes.NewBuffer(nil)
 	enc := NewEncoder(buf)

--- a/core/string.go
+++ b/core/string.go
@@ -216,7 +216,7 @@ func (enc *Encoder) writeSimpleString(s string) error {
 }
 
 func (enc *Encoder) tryWriteIntString(s string) (bool, error) {
-	intVal, ok := isEncodableInteger(s)
+	intVal, ok := isEncodableUint32(s)
 	if !ok {
 		return false, nil
 	}
@@ -326,7 +326,7 @@ func (enc *Encoder) writeFloat64(f float64) error {
 // can be encoded and then decoded back.
 // e.g. the following strings can not be encoded as an integer:
 // "007", "-0", "-1", "+0", "+1", "0x11"
-func isEncodableInteger(s string) (int64, bool) {
+func isEncodableUint32(s string) (int64, bool) {
 	if s == "" {
 		return 0, false
 	}

--- a/core/string_test.go
+++ b/core/string_test.go
@@ -88,8 +88,6 @@ func TestStringEncoding(t *testing.T) {
 }
 
 func TestRandomStringEncoding(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
-	enc := NewEncoder(buf)
 	size := 1000
 	round := 2000
 	strList := make([]string, size)
@@ -97,6 +95,8 @@ func TestRandomStringEncoding(t *testing.T) {
 		for i := 0; i < size; i++ {
 			strList[i] = RandString(rand.Intn(50))
 		}
+		buf := bytes.NewBuffer(nil)
+		enc := NewEncoder(buf)
 		for _, str := range strList {
 			err := enc.writeString(str)
 			if err != nil {

--- a/core/string_test.go
+++ b/core/string_test.go
@@ -62,7 +62,7 @@ func TestStringEncoding(t *testing.T) {
 		strconv.Itoa(math.MaxInt64),
 		strconv.Itoa(math.MinInt64),
 		strconv.Itoa(math.MinInt64) + "1",
-		strings.Repeat("long string", 20000),
+		RandString(20000),
 	}
 	for _, str := range strList {
 		err := enc.writeString(str)

--- a/core/string_test.go
+++ b/core/string_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"math"
+	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
@@ -57,9 +58,11 @@ func TestStringEncoding(t *testing.T) {
 		strconv.Itoa(math.MaxInt16),
 		strconv.Itoa(math.MinInt16),
 		strconv.Itoa(math.MaxInt32),
+		strconv.Itoa(math.MaxInt32) + "1",
 		strconv.Itoa(math.MinInt32),
 		strconv.Itoa(math.MinInt32) + "1",
 		strconv.Itoa(math.MaxInt64),
+		strconv.Itoa(math.MaxInt64) + "1",
 		strconv.Itoa(math.MinInt64),
 		strconv.Itoa(math.MinInt64) + "1",
 		RandString(20000),
@@ -80,6 +83,37 @@ func TestStringEncoding(t *testing.T) {
 		}
 		if string(actual) != expect {
 			t.Errorf("expect %s, actual %s", expect, string(actual))
+		}
+	}
+}
+
+func TestRandomStringEncoding(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	enc := NewEncoder(buf)
+	size := 1000
+	round := 2000
+	strList := make([]string, size)
+	for r := 0; r < round; r++ {
+		for i := 0; i < size; i++ {
+			strList[i] = RandString(rand.Intn(50))
+		}
+		for _, str := range strList {
+			err := enc.writeString(str)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+		}
+		dec := NewDecoder(buf)
+		for _, expect := range strList {
+			actual, err := dec.readString()
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+			if string(actual) != expect {
+				t.Errorf("expect %s, actual %s", expect, string(actual))
+			}
 		}
 	}
 }

--- a/core/string_test.go
+++ b/core/string_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"bytes"
+	"math"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -38,10 +40,29 @@ func TestStringEncoding(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	enc := NewEncoder(buf)
 	strList := []string{
+		"",
 		"abc",
 		"12",
 		"32766",
-		"2147483647",
+		"007",
+		"0",
+		"+0",
+		"-0",
+		"+1",
+		"-1",
+		"0x11",
+		"0o00",
+		strconv.Itoa(math.MaxInt8),
+		strconv.Itoa(math.MinInt8),
+		strconv.Itoa(math.MaxInt16),
+		strconv.Itoa(math.MinInt16),
+		strconv.Itoa(math.MaxInt32),
+		strconv.Itoa(math.MinInt32),
+		strconv.Itoa(math.MinInt32) + "1",
+		strconv.Itoa(math.MaxInt64),
+		strconv.Itoa(math.MinInt64),
+		strconv.Itoa(math.MinInt64) + "1",
+		strings.Repeat("long string", 20000),
 	}
 	for _, str := range strList {
 		err := enc.writeString(str)

--- a/core/zset_test.go
+++ b/core/zset_test.go
@@ -35,6 +35,16 @@ func TestZSetEncoding(t *testing.T) {
 				Score:  2.8,
 			},
 		},
+		"007": {
+			{
+				Member: "000",
+				Score:  3.1,
+			},
+			{
+				Member: "0x10",
+				Score:  9.99,
+			},
+		},
 		"large": entries,
 	}
 	buf := bytes.NewBuffer(nil)


### PR DESCRIPTION
encoder should be strict about the strings that can be encoded as integer.
as strconv.ParseInt() is not accurate for this case, we need to check the string content and pick up
the "pure" uint32 or uint64 numbers.

Also the WriteSetObject() function has a wrong state to fix.

Fix issue https://github.com/HDT3213/rdb/issues/38
Fix issue https://github.com/HDT3213/rdb/issues/40