### PR TITLE
intSize calculation error in IntSet encoding

### DIFF
--- a/core/set.go
+++ b/core/set.go
@@ -139,7 +139,8 @@ func (enc *Encoder) tryWriteIntSetEncoding(key string, values [][]byte) (bool, e
 		}
 		if intV < min {
 			min = intV
-		} else if intV > max {
+		}
+		if intV > max {
 			max = intV
 		}
 		intList[i] = intV

--- a/core/set_test.go
+++ b/core/set_test.go
@@ -2,8 +2,9 @@ package core
 
 import (
 	"bytes"
-	"github.com/hdt3213/rdb/model"
 	"testing"
+
+	"github.com/hdt3213/rdb/model"
 )
 
 func TestSetEncoding(t *testing.T) {
@@ -25,6 +26,9 @@ func TestSetEncoding(t *testing.T) {
 		},
 		"007": {
 			[]byte("-1"), []byte("02"), []byte("0x3"), []byte("0o4"),
+		},
+		"int4": {
+			[]byte("32768"),
 		},
 	}
 	buf := bytes.NewBuffer(nil)


### PR DESCRIPTION
When there is only one Set element or the elements are in descending order, `max` will default to math.MinInt64, and `intSize` will always return 2 bytes, resulting in data write errors.