### PR TITLE
feat(core/decoder): support opCode SlotInfo(244)

### DIFF
--- a/core/decoder.go
+++ b/core/decoder.go
@@ -54,6 +54,7 @@ const (
 )
 
 const (
+	opCodeSlotInfo     = 244
 	opCodeFunction     = 245
 	opCodeModuleAux    = 247 /* Module auxiliary data. */
 	opCodeIdle         = 248 /* LRU idle time. */
@@ -464,6 +465,23 @@ func (dec *Decoder) parse(cb func(object model.RedisObject) bool) error {
 				if !tbc {
 					break
 				}
+			}
+			continue
+		} else if b == opCodeSlotInfo {
+			// slot
+			_, _, err = dec.readLength()
+			if err != nil {
+				return err
+			}
+			// slot size
+			_, _, err = dec.readLength()
+			if err != nil {
+				return err
+			}
+			// slot expires
+			_, _, err = dec.readLength()
+			if err != nil {
+				return err
 			}
 			continue
 		}


### PR DESCRIPTION
- In PR [#11695](https://github.com/redis/redis/pull/11695/files#diff-c77a3d2b15213159471dad3359f23629c2297c3579861945e94ff05c34bb3d7dR1330-R1343) a new opcode `RDB_OPCODE_SLOT_INFO` was added to the Redis RDB file.
- This PR adds support for this opcode:
  - New opcode defined as `244`
  - Read and ignore fields in this opcode