### PR TITLE
Add support for RDB 13

### DIFF
--- a/core/decoder.go
+++ b/core/decoder.go
@@ -96,7 +96,7 @@ const (
 	typeHashListPackWithHfeRc // rdb 12 (only redis 7.4 rc)
 	typeHashWithHfe           // since rdb 12 (redis 7.4)
 	typeHashListPackWithHfe   // since rdb 12 (redis 7.4)
-	typeStreamListPacks4      // since rdb 13
+	typeStreamListPacks4      // since rdb 13 (redis 8.6)
 )
 
 const (

--- a/core/decoder.go
+++ b/core/decoder.go
@@ -50,20 +50,23 @@ var magicNumber = []byte("REDIS")
 
 const (
 	minVersion = 1
-	maxVersion = 12
+	maxVersion = 13
 )
 
 const (
-	opCodeFunction     = 245
-	opCodeModuleAux    = 247 /* Module auxiliary data. */
-	opCodeIdle         = 248 /* LRU idle time. */
-	opCodeFreq         = 249 /* LFU frequency. */
-	opCodeAux          = 250 /* RDB aux field. */
-	opCodeResizeDB     = 251 /* Hash table resize hint. */
-	opCodeExpireTimeMs = 252 /* Expire time in milliseconds. */
-	opCodeExpireTime   = 253 /* Old expire time in seconds. */
-	opCodeSelectDB     = 254 /* DB number of the following keys. */
-	opCodeEOF          = 255
+	opCodeKeyMeta       = 243 /* Key metadata (RDB 13). */
+	opCodeSlotInfo      = 244 /* Slot info for cluster mode (RDB 12+). */
+	opCodeFunction      = 245 /* Function library (aka FUNCTION2). */
+	opCodeFunctionPreGA = 246 /* Pre-release function format (unsupported). */
+	opCodeModuleAux     = 247 /* Module auxiliary data. */
+	opCodeIdle          = 248 /* LRU idle time. */
+	opCodeFreq          = 249 /* LFU frequency. */
+	opCodeAux           = 250 /* RDB aux field. */
+	opCodeResizeDB      = 251 /* Hash table resize hint. */
+	opCodeExpireTimeMs  = 252 /* Expire time in milliseconds. */
+	opCodeExpireTime    = 253 /* Old expire time in seconds. */
+	opCodeSelectDB      = 254 /* DB number of the following keys. */
+	opCodeEOF           = 255
 )
 
 const (
@@ -93,6 +96,7 @@ const (
 	typeHashListPackWithHfeRc // rdb 12 (only redis 7.4 rc)
 	typeHashWithHfe           // since rdb 12 (redis 7.4)
 	typeHashListPackWithHfe   // since rdb 12 (redis 7.4)
+	typeStreamListPacks4      // since rdb 13
 )
 
 const (
@@ -124,6 +128,7 @@ var encodingMap = map[int]string{
 	typeHashListPackWithHfeRc: model.ListPackExEncoding,
 	typeHashWithHfe:           model.HashExEncoding,
 	typeHashListPackWithHfe:   model.ListPackExEncoding,
+	typeStreamListPacks4:      model.ListPackEncoding,
 }
 
 // checkHeader checks whether input has valid RDB file header
@@ -294,12 +299,14 @@ func (dec *Decoder) readObject(flag byte, base *model.BaseObject) (model.RedisOb
 			BaseObject: base,
 			Entries:    entries,
 		}, nil
-	case typeStreamListPacks, typeStreamListPacks2, typeStreamListPacks3:
+	case typeStreamListPacks, typeStreamListPacks2, typeStreamListPacks3, typeStreamListPacks4:
 		var version uint = 1
 		if flag == typeStreamListPacks2 {
 			version = 2
 		} else if flag == typeStreamListPacks3 {
 			version = 3
+		} else if flag == typeStreamListPacks4 {
+			version = 4
 		}
 		stream, err := dec.readStreamListPacks(version)
 		if err != nil {
@@ -466,6 +473,30 @@ func (dec *Decoder) parse(cb func(object model.RedisObject) bool) error {
 				}
 			}
 			continue
+		} else if b == opCodeSlotInfo {
+			// Cluster slot info: skip slot_id, slot_size, expires_slot_size
+			if _, _, err = dec.readLength(); err != nil {
+				return err
+			}
+			if _, _, err = dec.readLength(); err != nil {
+				return err
+			}
+			if _, _, err = dec.readLength(); err != nil {
+				return err
+			}
+			continue
+		} else if b == opCodeFunctionPreGA {
+			return errors.New("pre-release function format (RDB_OPCODE_FUNCTION_PRE_GA) is not supported")
+		} else if b == opCodeKeyMeta {
+			// Key metadata (RDB 13): read and skip metadata classes,
+			// then read the real type byte which follows.
+			if err = dec.skipKeyMeta(); err != nil {
+				return err
+			}
+			b, err = dec.readByte()
+			if err != nil {
+				return err
+			}
 		}
 		key, err := dec.readString()
 		if err != nil {
@@ -513,4 +544,24 @@ func (dec *Decoder) Parse(cb func(object model.RedisObject) bool) (err error) {
 
 func (dec *Decoder) GetReadCount() int {
 	return dec.readCount
+}
+
+// skipKeyMeta reads and discards key metadata classes (RDB 13).
+// Format: [numClasses] then for each class: [4-byte classSpec] [module-value]
+func (dec *Decoder) skipKeyMeta() error {
+	numClasses, _, err := dec.readLength()
+	if err != nil {
+		return fmt.Errorf("read key meta numClasses failed: %v", err)
+	}
+	for i := uint64(0); i < numClasses; i++ {
+		// read 4-byte classSpec
+		if err := dec.readFull(dec.buffer[:4]); err != nil {
+			return fmt.Errorf("read key meta classSpec failed: %v", err)
+		}
+		// skip the module-encoded value
+		if _, err := skipModuleAuxData(moduleTypeHandlerImpl{dec: dec}, 0); err != nil {
+			return fmt.Errorf("skip key meta value failed: %v", err)
+		}
+	}
+	return nil
 }

--- a/core/encoder.go
+++ b/core/encoder.go
@@ -147,7 +147,7 @@ func (enc *Encoder) write(p []byte) error {
 	return nil
 }
 
-var rdbHeader = []byte("REDIS0011")
+var rdbHeader = []byte("REDIS0013")
 
 func (enc *Encoder) validateStateChange(toState string) bool {
 	_, ok := stateChanges[enc.state][toState]

--- a/core/hash.go
+++ b/core/hash.go
@@ -347,11 +347,14 @@ func (enc *Encoder) writeHashEncodingEx(key string, hash map[string][]byte, expi
 		return err
 	}
 	// Hash with HFEs. min TTL at start (7.4+), 7.4RC not included
-	var minExpire int64 = 0
+	var minExpire int64 = EB_EXPIRE_TIME_INVALID
 	for _, e := range expire {
-		if e > minExpire {
+		if e > 0 && e < minExpire {
 			minExpire = e
 		}
+	}
+	if minExpire == EB_EXPIRE_TIME_INVALID {
+		minExpire = 0
 	}
 	minExpireBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(minExpireBytes[:], uint64(minExpire))
@@ -364,7 +367,11 @@ func (enc *Encoder) writeHashEncodingEx(key string, hash map[string][]byte, expi
 		return err
 	}
 	for field, value := range hash {
-		err = enc.writeLength(uint64(expire[field] + 1 - minExpire))
+		var ttl uint64
+		if expire[field] > 0 {
+			ttl = uint64(expire[field] - minExpire + 1)
+		}
+		err = enc.writeLength(ttl)
 		if err != nil {
 			return err
 		}

--- a/core/stream.go
+++ b/core/stream.go
@@ -58,6 +58,13 @@ func (dec *Decoder) readStreamListPacks(version uint) (*model.StreamObject, erro
 		return nil, err
 	}
 	stream.Groups = groups
+
+	if version >= 4 {
+		if err = dec.readStreamIdmp(stream); err != nil {
+			return nil, err
+		}
+	}
+
 	stream.Version = version
 	return stream, nil
 }
@@ -216,6 +223,70 @@ func (dec *Decoder) readStreamEntryContent(buf []byte, cursor *int, firstId *mod
 	}, nil
 }
 
+func (dec *Decoder) readStreamIdmp(stream *model.StreamObject) error {
+	duration, _, err := dec.readLength()
+	if err != nil {
+		return fmt.Errorf("read idmp duration failed: %v", err)
+	}
+	stream.IdmpDuration = duration
+
+	maxEntries, _, err := dec.readLength()
+	if err != nil {
+		return fmt.Errorf("read idmp max entries failed: %v", err)
+	}
+	stream.IdmpMaxEntries = maxEntries
+
+	numProducers, _, err := dec.readLength()
+	if err != nil {
+		return fmt.Errorf("read idmp num producers failed: %v", err)
+	}
+	producers := make([]*model.StreamProducer, 0, numProducers)
+	for i := uint64(0); i < numProducers; i++ {
+		pid, err := dec.readString()
+		if err != nil {
+			return fmt.Errorf("read idmp producer id failed: %v", err)
+		}
+		count, _, err := dec.readLength()
+		if err != nil {
+			return fmt.Errorf("read idmp entry count failed: %v", err)
+		}
+		entries := make([]*model.StreamIdmpEntry, 0, count)
+		for j := uint64(0); j < count; j++ {
+			iid, err := dec.readString()
+			if err != nil {
+				return fmt.Errorf("read idmp iid failed: %v", err)
+			}
+			sid, err := dec.readStreamId()
+			if err != nil {
+				return fmt.Errorf("read idmp stream id failed: %v", err)
+			}
+			entries = append(entries, &model.StreamIdmpEntry{
+				Iid:      unsafeBytes2Str(iid),
+				StreamId: sid,
+			})
+		}
+		producers = append(producers, &model.StreamProducer{
+			Id:      unsafeBytes2Str(pid),
+			Entries: entries,
+		})
+	}
+	stream.IdmpProducers = producers
+
+	iidsAdded, _, err := dec.readLength()
+	if err != nil {
+		return fmt.Errorf("read iids added failed: %v", err)
+	}
+	stream.IidsAdded = iidsAdded
+
+	iidsDuplicates, _, err := dec.readLength()
+	if err != nil {
+		return fmt.Errorf("read iids duplicates failed: %v", err)
+	}
+	stream.IidsDuplicates = iidsDuplicates
+
+	return nil
+}
+
 func (dec *Decoder) readStreamGroups(version uint) ([]*model.StreamGroup, error) {
 	groupCount, _, err := dec.readLength()
 	if err != nil {
@@ -349,6 +420,8 @@ func (enc *Encoder) WriteStreamObject(key string, stream *model.StreamObject, op
 		streamType = typeStreamListPacks2
 	case 3:
 		streamType = typeStreamListPacks3
+	case 4:
+		streamType = typeStreamListPacks4
 	default:
 		streamType = typeStreamListPacks // default to version 1
 	}
@@ -421,8 +494,48 @@ func (enc *Encoder) WriteStreamObject(key string, stream *model.StreamObject, op
 		return err
 	}
 
+	// Write IDMP data (version 4+)
+	if stream.Version >= 4 {
+		if err = enc.writeStreamIdmp(stream); err != nil {
+			return err
+		}
+	}
+
 	enc.state = writtenObjectState
 	return nil
+}
+
+func (enc *Encoder) writeStreamIdmp(stream *model.StreamObject) error {
+	if err := enc.writeLength(stream.IdmpDuration); err != nil {
+		return err
+	}
+	if err := enc.writeLength(stream.IdmpMaxEntries); err != nil {
+		return err
+	}
+	producers := stream.IdmpProducers
+	if err := enc.writeLength(uint64(len(producers))); err != nil {
+		return err
+	}
+	for _, p := range producers {
+		if err := enc.writeString(p.Id); err != nil {
+			return err
+		}
+		if err := enc.writeLength(uint64(len(p.Entries))); err != nil {
+			return err
+		}
+		for _, e := range p.Entries {
+			if err := enc.writeString(e.Iid); err != nil {
+				return err
+			}
+			if err := enc.writeStreamId(e.StreamId); err != nil {
+				return err
+			}
+		}
+	}
+	if err := enc.writeLength(stream.IidsAdded); err != nil {
+		return err
+	}
+	return enc.writeLength(stream.IidsDuplicates)
 }
 
 // writeStreamId writes a stream ID

--- a/core/stream.go
+++ b/core/stream.go
@@ -294,7 +294,7 @@ func (dec *Decoder) readStreamGroups(version uint) ([]*model.StreamGroup, error)
 	}
 	groups := make([]*model.StreamGroup, 0, int(groupCount))
 	for i := uint64(0); i < groupCount; i++ {
-		name, _ := dec.readString()
+		name, err := dec.readString()
 		if err != nil {
 			return nil, err
 		}

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -322,6 +322,130 @@ func TestWriteStreamObjectVersion3(t *testing.T) {
 	decodeStreamObject(t, &buf, stream)
 }
 
+func TestWriteStreamObjectVersion4(t *testing.T) {
+	stream := &model.StreamObject{
+		BaseObject: &model.BaseObject{
+			Key: "astream",
+		},
+		Version: 4,
+		Length:  1,
+		LastId: &model.StreamId{
+			Ms:       1704557973866,
+			Sequence: 0,
+		},
+		FirstId: &model.StreamId{
+			Ms:       1704557973866,
+			Sequence: 0,
+		},
+		MaxDeletedId: &model.StreamId{
+			Ms:       0,
+			Sequence: 0,
+		},
+		AddedEntriesCount: 1,
+		Entries: []*model.StreamEntry{
+			{
+				FirstMsgId: &model.StreamId{
+					Ms:       1704557973866,
+					Sequence: 0,
+				},
+				Fields: []string{"name"},
+				Msgs: []*model.StreamMessage{
+					{
+						Id: &model.StreamId{
+							Ms:       1704557973866,
+							Sequence: 0,
+						},
+						Fields:  map[string]string{"name": "Sara"},
+						Deleted: false,
+					},
+				},
+			},
+		},
+		Groups: []*model.StreamGroup{},
+		IdmpDuration:   60000,
+		IdmpMaxEntries: 100,
+		IdmpProducers: []*model.StreamProducer{
+			{
+				Id: "producer-1",
+				Entries: []*model.StreamIdmpEntry{
+					{
+						Iid: "req-abc-123",
+						StreamId: &model.StreamId{
+							Ms:       1704557973866,
+							Sequence: 0,
+						},
+					},
+				},
+			},
+		},
+		IidsAdded:      5,
+		IidsDuplicates: 1,
+	}
+
+	var buf bytes.Buffer
+	encoder := NewEncoder(&buf)
+	if err := encoder.WriteHeader(); err != nil {
+		t.Fatalf("Failed to write header: %v", err)
+	}
+	if err := encoder.WriteDBHeader(0, 1, 0); err != nil {
+		t.Fatalf("Failed to write DB header: %v", err)
+	}
+	if err := encoder.WriteStreamObject("astream", stream); err != nil {
+		t.Fatalf("Failed to write stream object: %v", err)
+	}
+	if err := encoder.WriteEnd(); err != nil {
+		t.Fatalf("Failed to write end: %v", err)
+	}
+
+	// Decode and verify
+	decoder := NewDecoder(&buf)
+	var decoded *model.StreamObject
+	err := decoder.Parse(func(obj model.RedisObject) bool {
+		if s, ok := obj.(*model.StreamObject); ok {
+			decoded = s
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	if decoded == nil {
+		t.Fatal("Failed to decode stream object")
+	}
+	if decoded.Version != 4 {
+		t.Errorf("Version: expected 4, got %d", decoded.Version)
+	}
+	if decoded.IdmpDuration != 60000 {
+		t.Errorf("IdmpDuration: expected 60000, got %d", decoded.IdmpDuration)
+	}
+	if decoded.IdmpMaxEntries != 100 {
+		t.Errorf("IdmpMaxEntries: expected 100, got %d", decoded.IdmpMaxEntries)
+	}
+	if len(decoded.IdmpProducers) != 1 {
+		t.Fatalf("IdmpProducers count: expected 1, got %d", len(decoded.IdmpProducers))
+	}
+	p := decoded.IdmpProducers[0]
+	if p.Id != "producer-1" {
+		t.Errorf("Producer Id: expected producer-1, got %s", p.Id)
+	}
+	if len(p.Entries) != 1 {
+		t.Fatalf("Producer entries count: expected 1, got %d", len(p.Entries))
+	}
+	if p.Entries[0].Iid != "req-abc-123" {
+		t.Errorf("IDMP Iid: expected req-abc-123, got %s", p.Entries[0].Iid)
+	}
+	if p.Entries[0].StreamId.Ms != 1704557973866 {
+		t.Errorf("IDMP StreamId.Ms: expected 1704557973866, got %d", p.Entries[0].StreamId.Ms)
+	}
+	if decoded.IidsAdded != 5 {
+		t.Errorf("IidsAdded: expected 5, got %d", decoded.IidsAdded)
+	}
+	if decoded.IidsDuplicates != 1 {
+		t.Errorf("IidsDuplicates: expected 1, got %d", decoded.IidsDuplicates)
+	}
+}
+
 func decodeStreamObject(t *testing.T, buf *bytes.Buffer, stream *model.StreamObject) {
 	// Decode the stream object
 	decoder := NewDecoder(buf)

--- a/memprofiler/hash.go
+++ b/memprofiler/hash.go
@@ -26,7 +26,7 @@ func sizeOfHashObject(obj *model.HashObject) int {
 	if obj.GetEncoding() == model.ZipListEncoding {
 		extra := obj.Extra.(*model.ZiplistDetail)
 		return extra.RawStringSize
-	} else if obj.GetEncoding() == model.ListPackEncoding {
+	} else if obj.GetEncoding() == model.ListPackEncoding || obj.GetEncoding() == model.ListPackExEncoding {
 		extra := obj.Extra.(*model.ListpackDetail)
 		return extra.RawStringSize
 	}
@@ -35,6 +35,10 @@ func sizeOfHashObject(obj *model.HashObject) int {
 		size += hashTableEntryOverhead()
 		size += sizeOfString(k)
 		size += sizeOfString(unsafeBytes2Str(v))
+	}
+	if obj.GetEncoding() == model.HashExEncoding && len(obj.FieldExpirations) > 0 {
+		// Each field with expiration has an ebuckets entry (pointer + 8 bytes for the expire time)
+		size += len(obj.FieldExpirations) * (sizeOfPointer() + 8)
 	}
 	return size
 }

--- a/memprofiler/stream.go
+++ b/memprofiler/stream.go
@@ -23,6 +23,17 @@ func sizeOfStreamObject(obj *model.StreamObject) int {
 				sizeOfStreamRaxTree(len(consumer.Pending))
 		}
 	}
+	if obj.Version >= 4 {
+		size += 8 * 4 // IdmpDuration, IdmpMaxEntries, IidsAdded, IidsDuplicates
+		for _, producer := range obj.IdmpProducers {
+			size += sizeOfString(producer.Id)
+			// Each producer has a rax tree of idempotency entries
+			size += sizeOfStreamRaxTree(len(producer.Entries))
+			for _, entry := range producer.Entries {
+				size += sizeOfString(entry.Iid) + 16 // iid string + StreamId (two uint64)
+			}
+		}
+	}
 	return size
 }
 

--- a/model/stream.go
+++ b/model/stream.go
@@ -21,6 +21,12 @@ type StreamObject struct {
 	MaxDeletedId *StreamId `json:"maxDeletedId,omitempty"`
 	// AddedEntriesCount is count of elements added in all time. only valid in V2
 	AddedEntriesCount uint64 `json:"addedEntriesCount,omitempty"`
+	// IDMP fields (since V4 / RDB 13)
+	IdmpDuration   uint64             `json:"idmpDuration,omitempty"`
+	IdmpMaxEntries uint64             `json:"idmpMaxEntries,omitempty"`
+	IdmpProducers  []*StreamProducer  `json:"idmpProducers,omitempty"`
+	IidsAdded      uint64             `json:"iidsAdded,omitempty"`
+	IidsDuplicates uint64             `json:"iidsDuplicates,omitempty"`
 }
 
 func (obj *StreamObject) GetType() string {
@@ -71,6 +77,18 @@ type StreamNAck struct {
 	Id            *StreamId `json:"id"`
 	DeliveryTime  uint64    `json:"deliveryTime"`
 	DeliveryCount uint64    `json:"deliveryCount"`
+}
+
+// StreamProducer stores IDMP producer data (since RDB 13)
+type StreamProducer struct {
+	Id      string             `json:"id"`
+	Entries []*StreamIdmpEntry `json:"entries,omitempty"`
+}
+
+// StreamIdmpEntry is an idempotency entry within a producer
+type StreamIdmpEntry struct {
+	Iid      string    `json:"iid"`
+	StreamId *StreamId `json:"streamId"`
 }
 
 // StreamConsumer is a consumer


### PR DESCRIPTION
This PR add support for RDB 13. It is generated code, but tested against a prod RDB file converted to RDB version 13. This is not intended to be merged back to the original project, but simple unblock us from moving to Redis 8.6.